### PR TITLE
fixes before/after taxes discrepancy

### DIFF
--- a/app/models/junior_story.rb
+++ b/app/models/junior_story.rb
@@ -98,7 +98,7 @@ class JuniorStory < ActiveRecord::Base
   end
 
   def salary_sentence
-    "My salary is #{salary} #{currency} per year after taxes."
+    "My salary is #{salary} #{currency} per year before taxes."
   end
 
   def happy_in_job_sentence


### PR DESCRIPTION
Changes model sentence method to fix discrepancy between creation and showing of salary entries where one said `before taxes` and the other said `after taxtes`