### PR TITLE
abusing rails admin for filtering and export

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,3 +53,5 @@ group :development, :test do
 
 end
 
+gem 'rails_admin', :git => 'git://github.com/sferik/rails_admin.git'
+

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,22 @@
+GIT
+  remote: git://github.com/sferik/rails_admin.git
+  revision: 95ad1c2dc28234d1fcf7db7d5e1fd989989a0c05
+  specs:
+    rails_admin (0.8.1)
+      builder (~> 3.1)
+      coffee-rails (~> 4.0)
+      font-awesome-rails (>= 3.0, < 5)
+      haml (~> 4.0)
+      jquery-rails (>= 3.0, < 5)
+      jquery-ui-rails (~> 5.0)
+      kaminari (~> 0.14)
+      nested_form (~> 0.3)
+      rack-pjax (~> 0.7)
+      rails (~> 4.0)
+      remotipart (~> 1.0)
+      safe_yaml (~> 1.0)
+      sass-rails (>= 4.0, < 6)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -71,8 +90,12 @@ GEM
     factory_girl_rails (4.5.0)
       factory_girl (~> 4.5.0)
       railties (>= 3.0.0)
+    font-awesome-rails (4.5.0.0)
+      railties (>= 3.2, < 5.0)
     globalid (0.3.6)
       activesupport (>= 4.1.0)
+    haml (4.0.7)
+      tilt
     i18n (0.7.0)
     i18n_data (0.7.0)
     jbuilder (2.3.2)
@@ -82,7 +105,12 @@ GEM
       rails-dom-testing (~> 1.0)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jquery-ui-rails (5.0.5)
+      railties (>= 3.2.16)
     json (1.8.3)
+    kaminari (0.16.3)
+      actionpack (>= 3.0.0)
+      activesupport (>= 3.0.0)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -92,6 +120,7 @@ GEM
     mini_portile (0.6.2)
     minitest (5.8.3)
     multi_json (1.11.2)
+    nested_form (0.3.2)
     nokogiri (1.6.6.4)
       mini_portile (~> 0.6.0)
     pry (0.10.3)
@@ -101,6 +130,9 @@ GEM
     pry-rails (0.3.4)
       pry (>= 0.9.10)
     rack (1.6.4)
+    rack-pjax (0.8.0)
+      nokogiri (~> 1.5)
+      rack (~> 1.1)
     rack-test (0.6.3)
       rack (>= 1.0)
     rails (4.2.3)
@@ -129,6 +161,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (10.4.2)
     rdoc (4.2.0)
+    remotipart (1.2.1)
     rspec-core (3.3.2)
       rspec-support (~> 3.3.0)
     rspec-expectations (3.3.1)
@@ -146,6 +179,7 @@ GEM
       rspec-mocks (~> 3.3.0)
       rspec-support (~> 3.3.0)
     rspec-support (3.3.0)
+    safe_yaml (1.0.4)
     sass (3.4.19)
     sass-rails (5.0.4)
       railties (>= 4.0.0, < 5.0)
@@ -200,6 +234,7 @@ DEPENDENCIES
   jquery-rails
   pry-rails
   rails (= 4.2.3)
+  rails_admin!
   rspec-rails (~> 3.0)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
@@ -211,4 +246,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.10.5
+   1.10.6

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -1,6 +1,7 @@
 RailsAdmin.config do |config|
   config.actions do
-    # no root actions
+    # root actions
+    dashboard
     # only index collection action
     index
     # new, edit etc is NOT allowed

--- a/config/initializers/rails_admin.rb
+++ b/config/initializers/rails_admin.rb
@@ -1,0 +1,11 @@
+RailsAdmin.config do |config|
+  config.actions do
+    # no root actions
+    # only index collection action
+    index
+    # new, edit etc is NOT allowed
+    export
+    # member actions: only show
+    show
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,4 +3,6 @@ Rails.application.routes.draw do
   root 'pages#index'
 
   resources :junior_stories
+
+  mount RailsAdmin::Engine => '/details', as: 'rails_admin'
 end


### PR DESCRIPTION
To have filtering options we can 'abuse' RailsAdmin to our liking. Of course this breaks actual, 'proper' railsadmin use... Discuss!